### PR TITLE
Add support to load views directly from any registered Tipoff package during testing 

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "orchestra/testbench": "^6.0",
         "phpunit/phpunit": "^9.3",
         "spatie/laravel-ray": "^1.9",
-        "tipoff/support": "^1.5.2",
+        "tipoff/support": "^1.5.3",
         "vimeo/psalm": "^4.4"
     },
     "autoload": {

--- a/src/BaseTestCase.php
+++ b/src/BaseTestCase.php
@@ -57,6 +57,21 @@ abstract class BaseTestCase extends Orchestra
         }
     }
 
+    public function withViews(string $path, $app = null): self
+    {
+        if (!is_dir($path)) {
+            throw new \Exception('Invalid view path: '.$path);
+        }
+
+        $app = $app ?: $this->app;
+        $paths = array_merge($app['config']->get('view.paths'), [
+            $path,
+        ]);
+        $app['config']->set('view.paths', $paths);
+
+        return $this;
+    }
+
     /**
      * Useful to temporarily making logging output very visible during test execution for test
      * debugging purposes.


### PR DESCRIPTION
Also includes a `withViews(...)` helper to add any other paths to the search.