### PR TITLE
Set auth users model class to allow role assignment in tests

### DIFF
--- a/src/BaseTestCase.php
+++ b/src/BaseTestCase.php
@@ -59,6 +59,8 @@ abstract class BaseTestCase extends Orchestra
             $this->createStubModels();
         }
 
+        $app['config']->set('auth.providers.users.model', $app['config']->get('tipoff.model_class.user'));
+
         if ($this->stubNovaResources) {
             $this->createStubNovaResources();
         }


### PR DESCRIPTION
Hit this trying to assign Admin role to a user during testing of a nova route.