### PR TITLE
Use laravel fix for blade testing on Windows

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,6 +16,7 @@
     ],
     "require": {
         "php": "^7.4|^8.0",
+        "illuminate/testing": "^8.38",
         "mockery/mockery": "^1.4.3",
         "orchestra/testbench": "^6.0",
         "phpunit/phpunit": "^9.3",

--- a/src/BaseTestCase.php
+++ b/src/BaseTestCase.php
@@ -7,9 +7,6 @@ namespace Tipoff\TestSupport;
 use Illuminate\Foundation\Testing\Concerns\InteractsWithViews;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
-use Illuminate\Support\Facades\View as ViewFacade;
-use Illuminate\Support\Str;
-use Illuminate\Testing\TestView;
 use Illuminate\View\DynamicComponent;
 use Orchestra\Testbench\TestCase as Orchestra;
 use Tipoff\Support\Contracts\Models\UserInterface;
@@ -135,25 +132,6 @@ abstract class BaseTestCase extends Orchestra
 
         return $this;
     }
-
-    protected function blade(string $template, array $data = [])
-    {
-        $tempDirectory = sys_get_temp_dir();
-
-        if (! in_array($tempDirectory, ViewFacade::getFinder()->getPaths())) {
-            ViewFacade::addLocation(sys_get_temp_dir());
-        }
-
-        $tempFile = tempnam($tempDirectory, 'laravel-blade').'.blade.php';
-
-        // Fix for Github Actions ci/cd on windows - this strips any .tmp from the tempfile name generated
-        $tempFile = preg_replace('/\.tmp\.blade/', '.blade', $tempFile);
-
-        file_put_contents($tempFile, $template);
-
-        return new TestView(view(Str::before(basename($tempFile), '.blade.php'), $data));
-    }
-
 
     /**
      * Useful to temporarily making logging output very visible during test execution for test


### PR DESCRIPTION
No change in functionality, just removing our patch for temp blade files on windows now that Laravel includes its own fix for it in 8.38:

https://github.com/laravel/framework/pull/37044/files